### PR TITLE
HopperChains pass along tuples instead of images.

### DIFF
--- a/fishface/hopperchain.py
+++ b/fishface/hopperchain.py
@@ -60,7 +60,13 @@ class FileSource(object):
 
         image = cv2.imread(filename)
 
-        return image
+        return (
+            image,
+            {
+                'source_type': 'ImageSource',
+                'source_filename': filename,
+            }
+        )
 
 
 class ImageSource(object):
@@ -91,7 +97,12 @@ class ImageSource(object):
         except IndexError:
             raise StopIteration
 
-        return image
+        return (
+            image,
+            {
+                'source_type': 'ImageSource'
+            }
+        )
 
 
 class HopperChain(object):
@@ -141,10 +152,10 @@ class HopperChain(object):
     def next(self):
         """Returns the next image after the chain processes it."""
         try:
-            image = self._hopper_list[-1].next()
+            image, meta_data = self._hopper_list[-1].next()
         except StopIteration:
             raise
-        return image
+        return (image, meta_data)
 
     def chain_spec(self):
         return tuple(hop.spec for hop in self._hopper_list)

--- a/fishface/hoppers.py
+++ b/fishface/hoppers.py
@@ -44,10 +44,10 @@ class Hopper(object):
     def next(self):
         """Returns the next image after the hopper processes it."""
         try:
-            image = self.source.next()
+            image, meta_data = self.source.next()
         except StopIteration:
             raise
-        return self._process(image)
+        return (self._process(image), meta_data)
 
     def _process(self, image):
         return image

--- a/test/test_hopperchain.py
+++ b/test/test_hopperchain.py
@@ -63,7 +63,7 @@ class TestHopperChain(object):
     def test_filesource_by_dir(self):
         file_list = hopperchain._find_jpgs_in_dir(self._tmp_dir)
         source = hopperchain.FileSource(file_list=file_list)
-        for image in source:
+        for image, meta_data in source:
             nt.assert_is_instance(image, np.ndarray)
 
     def test_gray_scalehalf_thresh100_hopperchain(self):
@@ -77,7 +77,7 @@ class TestHopperChain(object):
                                             source_dir="../eph/")
 
         out_tmp_dir = tempfile.mkdtemp(prefix="FishFaceTESTOUT_")
-        for output_image in hop_chain:
+        for output_image, meta_data in hop_chain:
             file_handle, file_name = tempfile.mkstemp(suffix=".jpg",
                                                       dir=out_tmp_dir)
             cv2.imwrite(file_name, output_image)

--- a/test/test_hoppers.py
+++ b/test/test_hoppers.py
@@ -27,7 +27,7 @@ class FakeSource(object):
     def next(self):
         if self._first_run:
             self._first_run = False
-            return self._array
+            return (self._array, dict())
         else:
             raise StopIteration
 
@@ -60,7 +60,7 @@ class TestHoppers(object):
     def test_hopper_base(self):
         source = FakeSource(TEST_IMAGES['grayscale-blackfill-1x1'])
         hop = hoppers.Hopper(source)
-        for output_image in hop:
+        for output_image, meta_data in hop:
             nt.assert_true(np.array_equal(
                 TEST_IMAGES['grayscale-blackfill-1x1'],
                 output_image)
@@ -72,7 +72,7 @@ class TestHoppers(object):
             TEST_IMAGES['grayscale-blackfill-1x1'].copy()
         )
         hop = hoppers.HopperScale(source, factor=3)
-        for output_image in hop:
+        for output_image, meta_data in hop:
             nt.assert_true(np.array_equal(
                 TEST_IMAGES['grayscale-blackfill-3x3'],
                 output_image)
@@ -86,7 +86,7 @@ class TestHoppers(object):
             TEST_IMAGES['grayscale-whitetop-2x2'].copy()
         )
         hop = hoppers.HopperScale(source, factor=3)
-        for output_image in hop:
+        for output_image, meta_data in hop:
             nt.assert_true(np.array_equal(
                 whitetop_times_3,
                 output_image)
@@ -98,7 +98,7 @@ class TestHoppers(object):
         source = FakeSource(three_channel.copy())
 
         hop = hoppers.HopperConvertToGrayscale(source)
-        for output_image in hop:
+        for output_image, meta_data in hop:
             nt.assert_true(np.array_equal(
                 np.array([[207]]),
                 output_image)
@@ -109,7 +109,7 @@ class TestHoppers(object):
 
         for thresh in range(60, 255, 64):
             hop = hoppers.HopperThreshold(source, thresh)
-            for output_image in hop:
+            for output_image, meta_data in hop:
                 compare_to = TEST_IMAGES['grayscale-fourtone-2x2']
                 compare_to[compare_to>thresh] = 255
                 compare_to[compare_to<255] = 0
@@ -124,7 +124,7 @@ class TestHoppers(object):
         source = FakeSource(TEST_IMAGES['grayscale-blackfill-1x1'])
 
         hop = hoppers.HopperInvert(source)
-        for output_image in hop:
+        for output_image, meta_data in hop:
             nt.assert_true(np.array_equal(
                 TEST_IMAGES['grayscale-whitefill-1x1'],
                 output_image)
@@ -147,7 +147,7 @@ class TestHoppers(object):
 
 def main():
     source = FakeSource(TEST_IMAGES['grayscale-blackfill-1x1'])
-    for image in source:
+    for image, meta_data in source:
         print image
 
 


### PR DESCRIPTION
Instead of passing an image directly, the hoppers and hopperchains
will now pass tuples of length 2.  The first element of the pair is
the numpy array image, and the second is a dictionary of metadata.
