### PR TITLE
Raspi status monitor

### DIFF
--- a/django_fishface/djff/static/djff/base.css
+++ b/django_fishface/djff/static/djff/base.css
@@ -34,7 +34,6 @@
 
 .body-background { color: #FFDDAA }
 
-
 html, body
 {
     margin: 0;
@@ -311,4 +310,69 @@ div.shift_right {
 
 div#zero_unverified {
     display: none;
+}
+
+div#raspi_monitor {
+    position: absolute;
+    right: 1em;
+    background-color: cadetblue;
+    bottom: 1em;
+    padding: 5px;
+    border: 1px solid black;
+    line-height: 1.7;
+    text-align: center;
+    font-size: 10pt;
+}
+
+div#raspi_monitor .hover_wrapper .hover_text {
+    position: absolute;
+    bottom: 2em;
+    right: 16em;
+    background-color: palegreen;
+    visibility: collapse;
+    min-width: 15em;
+    border: 1px black solid;
+    text-align: justify;
+    padding: 3px;
+    line-height: 1;
+    font-weight: normal;
+}
+
+div#raspi_monitor .hover_wrapper:hover .hover_text {
+    visibility: visible;
+}
+
+div#raspi_monitor .monitor_status_box
+{
+    display: inline;
+    text-align: center;
+    border: 1px solid black;
+    padding: 2px;
+    width: 2em;
+    font-weight: bolder;
+}
+
+div#raspi_monitor .monitor_status_box
+{
+    display: inline;
+    text-align: center;
+    border: 1px solid black;
+    padding: 2px;
+    width: 2em;
+    font-weight: bolder;
+}
+
+div#raspi_monitor .psu_monitor_box
+{
+    background-color: #FFDDAA;
+}
+
+div#raspi_monitor .hw_monitor_label {
+    margin: 0;
+    padding: 2px;
+    line-height: 1;
+    font-size: 10pt;
+    border: 1px solid gray;
+    margin-bottom: 5px;
+    background-color: navajowhite;
 }

--- a/django_fishface/djff/static/djff/remote_hardware_monitor.js
+++ b/django_fishface/djff/static/djff/remote_hardware_monitor.js
@@ -31,6 +31,9 @@ $(document).ready(function() {
                     } else {
                         thr_status_element.css('background-color', 'red');
                     }
+
+                    $("#psu_monitor_voltage").html(data.psu_voltage_meas);
+                    $("#psu_monitor_current").html(data.psu_current_meas);
                 }
             },
             dataType: 'json'

--- a/django_fishface/djff/static/djff/remote_hardware_monitor.js
+++ b/django_fishface/djff/static/djff/remote_hardware_monitor.js
@@ -1,0 +1,46 @@
+$(document).ready(function() {
+
+    function refresh_remote_hardware_monitor() {
+        var payload = {
+            command: 'raspi_monitor'
+        };
+        $.ajax({
+            type: 'POST',
+            url: window.ff.telemetry_proxy_url,  // set by inline javascript on the main page
+            data: payload,
+            success: function (data, status, jqXHR) {
+                if (data.command=='raspi_monitor') {
+                    $('#RASPI').css('background-color', 'lightgreen');
+                } else {
+                    $('#RASPI').css('background-color', 'red');
+                }
+
+                for (idx in data.threads) {
+                    var thr = data.threads[idx];
+
+                    var thr_status_element_id = {
+                        capturejob_controller: 'CJC',
+                        current_framer: 'CF',
+                        deathcry_publisher: 'DP'
+                    }[thr.name];
+
+                    var thr_status_element = $("#" + thr_status_element_id);
+
+                    if (thr.delta < 2) {
+                        thr_status_element.css('background-color', 'lightgreen');
+                    } else {
+                        thr_status_element.css('background-color', 'red');
+                    }
+                }
+            },
+            dataType: 'json'
+        });
+    }
+
+    window.setInterval(
+        function() {
+            refresh_remote_hardware_monitor();
+        }, 2000);
+
+
+});  // end $(document).ready()

--- a/django_fishface/djff/templates/djff/base.html
+++ b/django_fishface/djff/templates/djff/base.html
@@ -56,6 +56,42 @@
 </div>
 
 <div id="preview_area">
+    <div id="raspi_monitor">
+        <p class="hw_monitor_label">Remote<br>Hardware<br>Monitor</p>
+        <span class="hover_wrapper monitor_status_box">
+            RASPI<span class="hover_text">Green means that the Raspberry Pi's master server reports
+            that it is running properly. (imagery_server)</span>
+        </span>
+        <br>
+        <span class="hover_wrapper monitor_status_box">
+            CF<span class="hover_text">Green means that the thread that refreshes the image from
+            the camera is running. (current_framer)</span>
+        </span>
+        <span class="hover_wrapper monitor_status_box">
+            CJC<span class="hover_text">Green means that the raspi is ready to process queued
+            capture jobs. (capturejob_controller)</span>
+        </span>
+        <span class="hover_wrapper monitor_status_box">
+            DP<span class="hover_text">Green means that the thread that publishes the final status
+            of completed jobs back to the database is running. (deathcry_publisher)</span>
+        </span>
+        <br>
+        <span class="hover_wrapper monitor_status_box psu_monitor_box">
+            <span id="psu_monitor_voltage">0</span> V<span class="hover_text">
+            The delivered voltage as measured by the power supply.</span>
+        </span>
+        <span class="hover_wrapper monitor_status_box psu_monitor_box">
+            <span id="psu_monitor_current">0</span> A<span class="hover_text">
+            The delivered current as measured by the power supply.</span>
+        </span>
+        <span class="hover_wrapper monitor_status_box psu_monitor_box">
+            <span id="output_enabled">OFF</span><span class="hover_text">
+            Whether or not the power supply's output is enabled.</span>
+        </span>
+
+    </div>
+
+
     {% block preview_area %}
     {% endblock %}
 </div>

--- a/django_fishface/djff/templates/djff/base.html
+++ b/django_fishface/djff/templates/djff/base.html
@@ -90,11 +90,6 @@
             <span id="psu_monitor_current">0</span> A<span class="hover_text">
             The delivered current as measured by the power supply.</span>
         </span>
-        <span class="hover_wrapper monitor_status_box psu_monitor_box">
-            <span id="output_enabled">OFF</span><span class="hover_text">
-            Whether or not the power supply's output is enabled.</span>
-        </span>
-
     </div>
 
 

--- a/django_fishface/djff/templates/djff/base.html
+++ b/django_fishface/djff/templates/djff/base.html
@@ -14,12 +14,18 @@
     <script type="text/javascript" src="{% static 'djff/moment-timezone.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'djff/moment-timezone-with-data-2010-2020.min.js' %}"></script>
 
+    <script type="text/javascript" src="{% static 'djff/remote_hardware_monitor.js' %}"></script>
+
     {% block localscript %}{% endblock %}
 
     <title>FishFace{% block pagetitle %}{% endblock %}</title>
 
     <script type="text/javascript">
         $(document).ready(function(){
+            if (window.ff == undefined) { window.ff = {}; }
+
+            window.ff.telemetry_proxy_url = "{% url 'djff:telemetry_proxy' %}";
+
             /*
              * Global FishFace javascript goes here.
              */
@@ -58,20 +64,20 @@
 <div id="preview_area">
     <div id="raspi_monitor">
         <p class="hw_monitor_label">Remote<br>Hardware<br>Monitor</p>
-        <span class="hover_wrapper monitor_status_box">
+        <span id="RASPI" class="hover_wrapper monitor_status_box">
             RASPI<span class="hover_text">Green means that the Raspberry Pi's master server reports
             that it is running properly. (imagery_server)</span>
         </span>
         <br>
-        <span class="hover_wrapper monitor_status_box">
+        <span id="CF" class="hover_wrapper monitor_status_box">
             CF<span class="hover_text">Green means that the thread that refreshes the image from
             the camera is running. (current_framer)</span>
         </span>
-        <span class="hover_wrapper monitor_status_box">
+        <span id="CJC" class="hover_wrapper monitor_status_box">
             CJC<span class="hover_text">Green means that the raspi is ready to process queued
             capture jobs. (capturejob_controller)</span>
         </span>
-        <span class="hover_wrapper monitor_status_box">
+        <span id="DP" class="hover_wrapper monitor_status_box">
             DP<span class="hover_text">Green means that the thread that publishes the final status
             of completed jobs back to the database is running. (deathcry_publisher)</span>
         </span>

--- a/raspberrypi/raspi_imagery_server.py
+++ b/raspberrypi/raspi_imagery_server.py
@@ -773,8 +773,8 @@ class ImageryServer(object):
     def monitor(self, payload):
         response = {
             'command': 'raspi_monitor',
-            'psu_voltage_meas': float(self.power_supply.voltage_sense),
-            'psu_current_meas': float(self.power_supply.current_sense),
+            'psu_voltage_meas': round(float(self.power_supply.voltage_sense), 3),
+            'psu_current_meas': round(float(self.power_supply.current_sense), 3),
         }
 
         response['threads'] = [{

--- a/raspberrypi/raspi_imagery_server.py
+++ b/raspberrypi/raspi_imagery_server.py
@@ -772,24 +772,30 @@ class ImageryServer(object):
 
     def monitor(self, payload):
         response = {
-            'command': 'imagery_server_monitor',
+            'command': 'raspi_status_monitor',
             'psu_voltage_meas': self.power_supply.voltage_sense,
             'psu_current_meas': self.power_supply.current_sense,
         }
 
         if self._current_job is not None:
-            response['current_job'] = self.get_current_job_status()
+            response['current_job_status'] = self.get_current_job_status()
             response['xp_id'] = response['current_job']['xp_id']
         else:
             response['xp_id'] = False
 
         if self._staged_job is not None:
-            response['staged_job'] = self.get_staged_job_status()
+            response['staged_job_status'] = self.get_staged_job_status()
 
         if self._queue:
             response['queue_count'] = len(self._queue)
         else:
             response['queue_count'] = 0
+
+        response['threads'] = [{
+            'name': thr.name,
+            'delta': thr.last_heartbeat_delta,
+            'last': thr.last_heartbeat,
+        } for thr in self.thread_registry]
 
         return response
 

--- a/raspberrypi/raspi_imagery_server.py
+++ b/raspberrypi/raspi_imagery_server.py
@@ -704,7 +704,7 @@ class ImageryServer(object):
             'abort_running_job': self.capturejob_controller.abort_running_job,
             'abort_all': self.capturejob_controller.abort_all_jobs,
 
-            'imagery_server_monitor': self.monitor,
+            'raspi_monitor': self.monitor,
         }
 
     def post_current_image_to_server(self, payload, sync=True):
@@ -772,24 +772,10 @@ class ImageryServer(object):
 
     def monitor(self, payload):
         response = {
-            'command': 'raspi_status_monitor',
-            'psu_voltage_meas': self.power_supply.voltage_sense,
-            'psu_current_meas': self.power_supply.current_sense,
+            'command': 'raspi_monitor',
+            'psu_voltage_meas': float(self.power_supply.voltage_sense),
+            'psu_current_meas': float(self.power_supply.current_sense),
         }
-
-        if self._current_job is not None:
-            response['current_job_status'] = self.get_current_job_status()
-            response['xp_id'] = response['current_job']['xp_id']
-        else:
-            response['xp_id'] = False
-
-        if self._staged_job is not None:
-            response['staged_job_status'] = self.get_staged_job_status()
-
-        if self._queue:
-            response['queue_count'] = len(self._queue)
-        else:
-            response['queue_count'] = 0
 
         response['threads'] = [{
             'name': thr.name,

--- a/raspberrypi/raspi_imagery_server.py
+++ b/raspberrypi/raspi_imagery_server.py
@@ -481,6 +481,8 @@ class ImageryServer(object):
 
             'abort_running_job': self.capturejob_controller.abort_running_job,
             'abort_all': self.capturejob_controller.abort_all,
+
+            'imagery_server_monitor': self.monitor,
         }
 
         self._heartbeat_icl = 0
@@ -558,6 +560,29 @@ class ImageryServer(object):
 
     def get_current_frame(self):
         return self._current_frame
+
+    def monitor(self, payload):
+        response = {
+            'command': 'imagery_server_monitor',
+            'psu_voltage_meas': self.power_supply.voltage_sense,
+            'psu_current_meas': self.power_supply.current_sense,
+        }
+
+        if self._current_job is not None:
+            response['current_job'] = self.get_current_job_status()
+            response['xp_id'] = response['current_job']['xp_id']
+        else:
+            response['xp_id'] = False
+
+        if self._staged_job is not None:
+            response['staged_job'] = self.get_staged_job_status()
+
+        if self._queue:
+            response['queue_count'] = len(self._queue)
+        else:
+            response['queue_count'] = 0
+
+        return response
 
     def run(self):
         def image_capture_loop():


### PR DESCRIPTION
Added a small remote hardware monitor box in the lower-right corner of the FishFace interface.