### PR TITLE
Remove CurrentFramer thread in favor of on-the-fly camera usage.

### DIFF
--- a/django_fishface/djff/static/djff/remote_hardware_monitor.js
+++ b/django_fishface/djff/static/djff/remote_hardware_monitor.js
@@ -12,7 +12,6 @@ $(document).ready(function() {
                     $('#RASPI').css('background-color', 'red');
                     $('#CJC').css('background-color', 'gray');
                     $('#DP').css('background-color', 'gray');
-                    $('#CF').css('background-color', 'gray');
             },
             success: function (data, status, jqXHR) {
                 if (data.command=='raspi_monitor') {
@@ -26,7 +25,6 @@ $(document).ready(function() {
 
                     var thr_status_element_id = {
                         capturejob_controller: 'CJC',
-                        current_framer: 'CF',
                         deathcry_publisher: 'DP'
                     }[thr.name];
 

--- a/django_fishface/djff/templates/djff/cq_interface.html
+++ b/django_fishface/djff/templates/djff/cq_interface.html
@@ -49,10 +49,6 @@ $(document).ready(function(){
             that it is running properly. (imagery_server)</span>
         </span>
         <br>
-        <span id="CF" class="hover_wrapper monitor_status_box">
-            CF<span class="hover_text">Green means that the thread that refreshes the image from
-            the camera is running. (current_framer)</span>
-        </span>
         <span id="CJC" class="hover_wrapper monitor_status_box">
             CJC<span class="hover_text">Green means that the raspi is ready to process queued
             capture jobs. (capturejob_controller)</span>

--- a/raspberrypi/FakeHardware.py
+++ b/raspberrypi/FakeHardware.py
@@ -17,6 +17,8 @@ class PiCamera(object):
         self.resolution = (2048, 1536)
         self.rotation = 180
 
+        self._closed = False
+
         with open(os.path.join(HOME_DIR, PROJECT_DIR,"sample-DATA.jpg"), 'rb') as f:
             self._fake_image = f.read()
 
@@ -25,6 +27,9 @@ class PiCamera(object):
         # of the use of it by picamera's capture().
         # plus, isn't Python's 'format' only used on
         # strings?
+        if self._closed:
+            raise NotImplementedError("Proper errors aren't implemented on fake hardware.")
+
         if format != 'jpeg':
             raise NotImplementedError("Can only fake jpegs currently.")
 
@@ -35,7 +40,11 @@ class PiCamera(object):
             raise Exception("Can only write to io.BytesIO streams.")
 
     def close(self):
-        pass
+        self._closed = True
+
+    @property
+    def closed(self):
+        return self._closed
 
 
 class HP6652a(object):


### PR DESCRIPTION
Switching from constantly polling the camera to shutting it down between jobs - and even between individual frames if they are far enough apart - to try to address infrequent but critical instability that had developed in the CurrentFramer thread.